### PR TITLE
Fix for invalid lexer state And type check for EQ, NEQ

### DIFF
--- a/evaluationFailure_test.go
+++ b/evaluationFailure_test.go
@@ -368,6 +368,18 @@ func TestComparatorTyping(test *testing.T) {
 			Input:    "1 in true",
 			Expected: INVALID_COMPARATOR_TYPES,
 		},
+		EvaluationFailureTest{
+
+			Name:     "EQ number to boolean",
+			Input:    "1 == true",
+			Expected: INVALID_COMPARATOR_TYPES,
+		},
+		EvaluationFailureTest{
+			Name:     "NEQ string to number",
+			Input:    "'hello' != 10",
+			Expected: INVALID_COMPARATOR_TYPES,
+		},
+		
 	}
 
 	runEvaluationFailureTests(evaluationTests, test)

--- a/evaluationStage.go
+++ b/evaluationStage.go
@@ -496,6 +496,13 @@ func comparatorTypeCheck(left interface{}, right interface{}) bool {
 	return false
 }
 
+/*
+	Equality checks should happend between same types
+*/	
+func equalityTypeCheck(left interface{}, right interface{}) bool {
+	return reflect.TypeOf(left) == reflect.TypeOf(right)
+}
+
 func isArray(value interface{}) bool {
 	switch value.(type) {
 	case []interface{}:

--- a/lexerState.go
+++ b/lexerState.go
@@ -65,13 +65,6 @@ var validLexerStates = []lexerState{
 
 			COMPARATOR,
 			MODIFIER,
-			NUMERIC,
-			BOOLEAN,
-			VARIABLE,
-			STRING,
-			PATTERN,
-			TIME,
-			CLAUSE,
 			CLAUSE_CLOSE,
 			LOGICALOP,
 			TERNARY,
@@ -182,7 +175,6 @@ var validLexerStates = []lexerState{
 			STRING,
 			BOOLEAN,
 			CLAUSE,
-			CLAUSE_CLOSE,
 		},
 	},
 	lexerState{
@@ -201,7 +193,6 @@ var validLexerStates = []lexerState{
 			STRING,
 			TIME,
 			CLAUSE,
-			CLAUSE_CLOSE,
 			PATTERN,
 		},
 	},
@@ -221,7 +212,6 @@ var validLexerStates = []lexerState{
 			STRING,
 			TIME,
 			CLAUSE,
-			CLAUSE_CLOSE,
 		},
 	},
 	lexerState{
@@ -237,7 +227,6 @@ var validLexerStates = []lexerState{
 			FUNCTION,
 			ACCESSOR,
 			CLAUSE,
-			CLAUSE_CLOSE,
 		},
 	},
 

--- a/parsingFailure_test.go
+++ b/parsingFailure_test.go
@@ -205,6 +205,31 @@ func TestParsingFailure(test *testing.T) {
 			Input:    "0x12g1",
 			Expected: INVALID_TOKEN_TRANSITION,
 		},
+		ParsingFailureTest{
+			Name:     "Invalid LOGICALOP transition",
+			Input:    "(a > 100 &&) == false",
+			Expected: INVALID_TOKEN_TRANSITION,
+		},
+		ParsingFailureTest{
+			Name:     "Invalid MODIFIER transition",
+			Input:    "(a + )",
+			Expected: INVALID_TOKEN_TRANSITION,
+		},
+		ParsingFailureTest{
+			Name:     "Invalid COMPARATOR transition",
+			Input:    "(a > )",
+			Expected: INVALID_TOKEN_TRANSITION,
+		},
+		ParsingFailureTest{
+			Name:     "Invalid PREFIX transition",
+			Input:    "(~)",
+			Expected: INVALID_TOKEN_TRANSITION,
+		},
+		ParsingFailureTest{
+			Name:     "Invalid CLAUSE_CLOSE transition",
+			Input:    "(a == b) c",
+			Expected: INVALID_TOKEN_TRANSITION,
+		},
 	}
 
 	runParsingFailureTests(parsingTests, test)

--- a/stagePlanner.go
+++ b/stagePlanner.go
@@ -534,12 +534,13 @@ func findTypeChecks(symbol OperatorSymbol) typeChecks {
 		return typeChecks{
 			left: isBool,
 		}
-
-	// unchecked cases
 	case EQ:
 		fallthrough
 	case NEQ:
-		return typeChecks{}
+		return typeChecks{
+			combined: equalityTypeCheck,
+		}
+	// unchecked cases
 	case TERNARY_FALSE:
 		fallthrough
 	case COALESCE:


### PR DESCRIPTION
Remove invalid lexer state transitions
Example:
Input:    "(a > )",
Expected: INVALID_TOKEN_TRANSITION,

Add stageCombinedTypeCheck for EQ, NEQ comparators
Example:
Input:    "1 == true",
Expected: INVALID_COMPARATOR_TYPES,
